### PR TITLE
fix: set initial state to match media query result

### DIFF
--- a/src/hooks/use-media-query.tsx
+++ b/src/hooks/use-media-query.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 
 export function useMediaQuery(query: string) {
-  const [value, setValue] = React.useState(false)
+  const [value, setValue] = React.useState(window.matchMedia(query).matches)
 
   React.useEffect(() => {
     function onChange(event: MediaQueryListEvent) {


### PR DESCRIPTION
This should stop the hook result from fluctating and causing the `DialogPortal must be used within Dialog`  error
