### PR TITLE
fixes Error: `DialogTrigger` must be used within `Dialog` #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,103 +91,122 @@ interface CredenzaProps extends BaseProps {
   asChild?: true
 }
 
-const desktop = "(min-width: 768px)"
+const CredenzaContext = React.createContext<{ isDesktop: boolean }>({
+  isDesktop: false,
+});
+
+const useCredenzaContext = () => {
+  const context = React.useContext(CredenzaContext);
+  if (!context) {
+    throw new Error(
+      "Credenza components cannot be rendered outside the Credenza Context",
+    );
+  }
+  return context;
+};
 
 const Credenza = ({ children, ...props }: RootCredenzaProps) => {
-  const isDesktop = useMediaQuery(desktop)
-  const Credenza = isDesktop ? Dialog : Drawer
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+  const Credenza = isDesktop ? Dialog : Drawer;
 
-  return <Credenza {...props}>{children}</Credenza>
-}
+  return (
+    <CredenzaContext.Provider value={{ isDesktop }}>
+      <Credenza {...props} {...(!isDesktop && { autoFocus: true })}>
+        {children}
+      </Credenza>
+    </CredenzaContext.Provider>
+  );
+};
+
 
 const CredenzaTrigger = ({ className, children, ...props }: CredenzaProps) => {
-  const isDesktop = useMediaQuery(desktop)
-  const CredenzaTrigger = isDesktop ? DialogTrigger : DrawerTrigger
+  const { isDesktop } = useCredenzaContext();
+  const CredenzaTrigger = isDesktop ? DialogTrigger : DrawerTrigger;
 
   return (
     <CredenzaTrigger className={className} {...props}>
       {children}
     </CredenzaTrigger>
-  )
-}
+  );
+};
 
 const CredenzaClose = ({ className, children, ...props }: CredenzaProps) => {
-  const isDesktop = useMediaQuery(desktop)
-  const CredenzaClose = isDesktop ? DialogClose : DrawerClose
+  const { isDesktop } = useCredenzaContext();
+  const CredenzaClose = isDesktop ? DialogClose : DrawerClose;
 
   return (
     <CredenzaClose className={className} {...props}>
       {children}
     </CredenzaClose>
-  )
-}
+  );
+};
 
 const CredenzaContent = ({ className, children, ...props }: CredenzaProps) => {
-  const isDesktop = useMediaQuery(desktop)
-  const CredenzaContent = isDesktop ? DialogContent : DrawerContent
+  const { isDesktop } = useCredenzaContext();
+  const CredenzaContent = isDesktop ? DialogContent : DrawerContent;
 
   return (
     <CredenzaContent className={className} {...props}>
       {children}
     </CredenzaContent>
-  )
-}
+  );
+};
 
 const CredenzaDescription = ({
   className,
   children,
   ...props
 }: CredenzaProps) => {
-  const isDesktop = useMediaQuery(desktop)
-  const CredenzaDescription = isDesktop ? DialogDescription : DrawerDescription
+  const { isDesktop } = useCredenzaContext();
+  const CredenzaDescription = isDesktop ? DialogDescription : DrawerDescription;
 
   return (
     <CredenzaDescription className={className} {...props}>
       {children}
     </CredenzaDescription>
-  )
-}
+  );
+};
 
 const CredenzaHeader = ({ className, children, ...props }: CredenzaProps) => {
-  const isDesktop = useMediaQuery(desktop)
-  const CredenzaHeader = isDesktop ? DialogHeader : DrawerHeader
+  const { isDesktop } = useCredenzaContext();
+  const CredenzaHeader = isDesktop ? DialogHeader : DrawerHeader;
 
   return (
     <CredenzaHeader className={className} {...props}>
       {children}
     </CredenzaHeader>
-  )
-}
+  );
+};
 
 const CredenzaTitle = ({ className, children, ...props }: CredenzaProps) => {
-  const isDesktop = useMediaQuery(desktop)
-  const CredenzaTitle = isDesktop ? DialogTitle : DrawerTitle
+  const { isDesktop } = useCredenzaContext();
+  const CredenzaTitle = isDesktop ? DialogTitle : DrawerTitle;
 
   return (
     <CredenzaTitle className={className} {...props}>
       {children}
     </CredenzaTitle>
-  )
-}
+  );
+};
 
 const CredenzaBody = ({ className, children, ...props }: CredenzaProps) => {
   return (
     <div className={cn("px-4 md:px-0", className)} {...props}>
       {children}
     </div>
-  )
-}
+  );
+};
 
 const CredenzaFooter = ({ className, children, ...props }: CredenzaProps) => {
-  const isDesktop = useMediaQuery(desktop)
-  const CredenzaFooter = isDesktop ? DialogFooter : DrawerFooter
+  const { isDesktop } = useCredenzaContext();
+  const CredenzaFooter = isDesktop ? DialogFooter : DrawerFooter;
 
   return (
     <CredenzaFooter className={className} {...props}>
       {children}
     </CredenzaFooter>
-  )
-}
+  );
+};
 
 export {
   Credenza,
@@ -200,6 +219,7 @@ export {
   CredenzaBody,
   CredenzaFooter,
 }
+
 ```
 
 </details>

--- a/src/components/blocks.tsx
+++ b/src/components/blocks.tsx
@@ -70,103 +70,122 @@ interface CredenzaProps extends BaseProps {
   asChild?: true
 }
 
-const desktop = "(min-width: 768px)"
+const CredenzaContext = React.createContext<{ isDesktop: boolean }>({
+  isDesktop: false,
+});
+
+const useCredenzaContext = () => {
+  const context = React.useContext(CredenzaContext);
+  if (!context) {
+    throw new Error(
+      "Credenza components cannot be rendered outside the Credenza Context",
+    );
+  }
+  return context;
+};
 
 const Credenza = ({ children, ...props }: RootCredenzaProps) => {
-  const isDesktop = useMediaQuery(desktop)
-  const Credenza = isDesktop ? Dialog : Drawer
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+  const Credenza = isDesktop ? Dialog : Drawer;
 
-  return <Credenza {...props}>{children}</Credenza>
-}
+  return (
+    <CredenzaContext.Provider value={{ isDesktop }}>
+      <Credenza {...props} {...(!isDesktop && { autoFocus: true })}>
+        {children}
+      </Credenza>
+    </CredenzaContext.Provider>
+  );
+};
+
 
 const CredenzaTrigger = ({ className, children, ...props }: CredenzaProps) => {
-  const isDesktop = useMediaQuery(desktop)
-  const CredenzaTrigger = isDesktop ? DialogTrigger : DrawerTrigger
+  const { isDesktop } = useCredenzaContext();
+  const CredenzaTrigger = isDesktop ? DialogTrigger : DrawerTrigger;
 
   return (
     <CredenzaTrigger className={className} {...props}>
       {children}
     </CredenzaTrigger>
-  )
-}
+  );
+};
 
 const CredenzaClose = ({ className, children, ...props }: CredenzaProps) => {
-  const isDesktop = useMediaQuery(desktop)
-  const CredenzaClose = isDesktop ? DialogClose : DrawerClose
+  const { isDesktop } = useCredenzaContext();
+  const CredenzaClose = isDesktop ? DialogClose : DrawerClose;
 
   return (
     <CredenzaClose className={className} {...props}>
       {children}
     </CredenzaClose>
-  )
-}
+  );
+};
 
 const CredenzaContent = ({ className, children, ...props }: CredenzaProps) => {
-  const isDesktop = useMediaQuery(desktop)
-  const CredenzaContent = isDesktop ? DialogContent : DrawerContent
+  const { isDesktop } = useCredenzaContext();
+  const CredenzaContent = isDesktop ? DialogContent : DrawerContent;
 
   return (
     <CredenzaContent className={className} {...props}>
       {children}
     </CredenzaContent>
-  )
-}
+  );
+};
 
 const CredenzaDescription = ({
   className,
   children,
   ...props
 }: CredenzaProps) => {
-  const isDesktop = useMediaQuery(desktop)
-  const CredenzaDescription = isDesktop ? DialogDescription : DrawerDescription
+  const { isDesktop } = useCredenzaContext();
+  const CredenzaDescription = isDesktop ? DialogDescription : DrawerDescription;
 
   return (
     <CredenzaDescription className={className} {...props}>
       {children}
     </CredenzaDescription>
-  )
-}
+  );
+};
 
 const CredenzaHeader = ({ className, children, ...props }: CredenzaProps) => {
-  const isDesktop = useMediaQuery(desktop)
-  const CredenzaHeader = isDesktop ? DialogHeader : DrawerHeader
+  const { isDesktop } = useCredenzaContext();
+  const CredenzaHeader = isDesktop ? DialogHeader : DrawerHeader;
 
   return (
     <CredenzaHeader className={className} {...props}>
       {children}
     </CredenzaHeader>
-  )
-}
+  );
+};
 
 const CredenzaTitle = ({ className, children, ...props }: CredenzaProps) => {
-  const isDesktop = useMediaQuery(desktop)
-  const CredenzaTitle = isDesktop ? DialogTitle : DrawerTitle
+  const { isDesktop } = useCredenzaContext();
+  const CredenzaTitle = isDesktop ? DialogTitle : DrawerTitle;
 
   return (
     <CredenzaTitle className={className} {...props}>
       {children}
     </CredenzaTitle>
-  )
-}
+  );
+};
 
 const CredenzaBody = ({ className, children, ...props }: CredenzaProps) => {
   return (
     <div className={cn("px-4 md:px-0", className)} {...props}>
       {children}
     </div>
-  )
-}
+  );
+};
 
 const CredenzaFooter = ({ className, children, ...props }: CredenzaProps) => {
-  const isDesktop = useMediaQuery(desktop)
-  const CredenzaFooter = isDesktop ? DialogFooter : DrawerFooter
+  const { isDesktop } = useCredenzaContext();
+  const CredenzaFooter = isDesktop ? DialogFooter : DrawerFooter;
 
   return (
     <CredenzaFooter className={className} {...props}>
       {children}
     </CredenzaFooter>
-  )
-}
+  );
+};
 
 export {
   Credenza,
@@ -178,7 +197,8 @@ export {
   CredenzaTitle,
   CredenzaBody,
   CredenzaFooter,
-}`}
+}
+`}
     </CodeBlock>
   )
 }

--- a/src/components/ui/credenza.tsx
+++ b/src/components/ui/credenza.tsx
@@ -39,103 +39,122 @@ interface CredenzaProps extends BaseProps {
   asChild?: true
 }
 
-const desktop = "(min-width: 768px)"
+const CredenzaContext = React.createContext<{ isDesktop: boolean }>({
+  isDesktop: false,
+});
+
+const useCredenzaContext = () => {
+  const context = React.useContext(CredenzaContext);
+  if (!context) {
+    throw new Error(
+      "Credenza components cannot be rendered outside the Credenza Context",
+    );
+  }
+  return context;
+};
 
 const Credenza = ({ children, ...props }: RootCredenzaProps) => {
-  const isDesktop = useMediaQuery(desktop)
-  const Credenza = isDesktop ? Dialog : Drawer
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+  const Credenza = isDesktop ? Dialog : Drawer;
 
-  return <Credenza {...props}>{children}</Credenza>
-}
+  return (
+    <CredenzaContext.Provider value={{ isDesktop }}>
+      <Credenza {...props} {...(!isDesktop && { autoFocus: true })}>
+        {children}
+      </Credenza>
+    </CredenzaContext.Provider>
+  );
+};
+
 
 const CredenzaTrigger = ({ className, children, ...props }: CredenzaProps) => {
-  const isDesktop = useMediaQuery(desktop)
-  const CredenzaTrigger = isDesktop ? DialogTrigger : DrawerTrigger
+  const { isDesktop } = useCredenzaContext();
+  const CredenzaTrigger = isDesktop ? DialogTrigger : DrawerTrigger;
 
   return (
     <CredenzaTrigger className={className} {...props}>
       {children}
     </CredenzaTrigger>
-  )
-}
+  );
+};
 
 const CredenzaClose = ({ className, children, ...props }: CredenzaProps) => {
-  const isDesktop = useMediaQuery(desktop)
-  const CredenzaClose = isDesktop ? DialogClose : DrawerClose
+  const { isDesktop } = useCredenzaContext();
+  const CredenzaClose = isDesktop ? DialogClose : DrawerClose;
 
   return (
     <CredenzaClose className={className} {...props}>
       {children}
     </CredenzaClose>
-  )
-}
+  );
+};
 
 const CredenzaContent = ({ className, children, ...props }: CredenzaProps) => {
-  const isDesktop = useMediaQuery(desktop)
-  const CredenzaContent = isDesktop ? DialogContent : DrawerContent
+  const { isDesktop } = useCredenzaContext();
+  const CredenzaContent = isDesktop ? DialogContent : DrawerContent;
 
   return (
     <CredenzaContent className={className} {...props}>
       {children}
     </CredenzaContent>
-  )
-}
+  );
+};
 
 const CredenzaDescription = ({
   className,
   children,
   ...props
 }: CredenzaProps) => {
-  const isDesktop = useMediaQuery(desktop)
-  const CredenzaDescription = isDesktop ? DialogDescription : DrawerDescription
+  const { isDesktop } = useCredenzaContext();
+  const CredenzaDescription = isDesktop ? DialogDescription : DrawerDescription;
 
   return (
     <CredenzaDescription className={className} {...props}>
       {children}
     </CredenzaDescription>
-  )
-}
+  );
+};
 
 const CredenzaHeader = ({ className, children, ...props }: CredenzaProps) => {
-  const isDesktop = useMediaQuery(desktop)
-  const CredenzaHeader = isDesktop ? DialogHeader : DrawerHeader
+  const { isDesktop } = useCredenzaContext();
+  const CredenzaHeader = isDesktop ? DialogHeader : DrawerHeader;
 
   return (
     <CredenzaHeader className={className} {...props}>
       {children}
     </CredenzaHeader>
-  )
-}
+  );
+};
 
 const CredenzaTitle = ({ className, children, ...props }: CredenzaProps) => {
-  const isDesktop = useMediaQuery(desktop)
-  const CredenzaTitle = isDesktop ? DialogTitle : DrawerTitle
+  const { isDesktop } = useCredenzaContext();
+  const CredenzaTitle = isDesktop ? DialogTitle : DrawerTitle;
 
   return (
     <CredenzaTitle className={className} {...props}>
       {children}
     </CredenzaTitle>
-  )
-}
+  );
+};
 
 const CredenzaBody = ({ className, children, ...props }: CredenzaProps) => {
   return (
     <div className={cn("px-4 md:px-0", className)} {...props}>
       {children}
     </div>
-  )
-}
+  );
+};
 
 const CredenzaFooter = ({ className, children, ...props }: CredenzaProps) => {
-  const isDesktop = useMediaQuery(desktop)
-  const CredenzaFooter = isDesktop ? DialogFooter : DrawerFooter
+  const { isDesktop } = useCredenzaContext();
+  const CredenzaFooter = isDesktop ? DialogFooter : DrawerFooter;
 
   return (
     <CredenzaFooter className={className} {...props}>
       {children}
     </CredenzaFooter>
-  )
-}
+  );
+};
 
 export {
   Credenza,


### PR DESCRIPTION
Solves the error by using a React Context to pass the isDesktop boolean to the components